### PR TITLE
Implement animated role cycling on homepage

### DIFF
--- a/my-app/src/home.js
+++ b/my-app/src/home.js
@@ -1,8 +1,32 @@
 import './main.css';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 const Home = ({ setPage }) => {
   const [showAllNews, setShowAllNews] = useState(false);
+  const titles = [
+    'sophomore',
+    'machine learning researcher',
+    'soccer fan',
+    'developer',
+    'tutor',
+    'startup enthusiast'
+  ];
+  const colors = [
+    '#ffadad',
+    '#ffd6a5',
+    '#caffbf',
+    '#9bf6ff',
+    '#a0c4ff',
+    '#bdb2ff'
+  ];
+  const [titleIndex, setTitleIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setTitleIndex((prev) => (prev + 1) % titles.length);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
 
   const newsItems = [
     {
@@ -39,7 +63,17 @@ const Home = ({ setPage }) => {
       <div className="hero-section">
         <div className="hero">
           <h1 className="subhead">Haoming Chen</h1>
-          <p className="header"> I am a sophomore at UC Berkeley studying Computer Science and Mathematics.</p>
+          <p className="header">
+            I am a{' '}
+            <span
+              key={titleIndex}
+              className="animated-word"
+              style={{ backgroundColor: colors[titleIndex] }}
+            >
+              {titles[titleIndex]}
+            </span>{' '}
+            at UC Berkeley studying Computer Science and Mathematics.
+          </p>
         </div>
         <div className="hero-image">
           <img src="/hero.jpg" alt="Haoming" />

--- a/my-app/src/main.css
+++ b/my-app/src/main.css
@@ -677,3 +677,23 @@
     height: 120px;
   }
 }
+
+.animated-word {
+  display: inline-block;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  color: #333;
+  animation: slideIn 0.5s;
+  transition: background-color 0.5s;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- animate role on homepage so 'sophomore' cycles through multiple labels
- style animated words with sliding animation and color backgrounds

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866126c261c8325b56eef92510b0132